### PR TITLE
set PYTHON_INTERPRETER as python2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,7 +36,9 @@ if (NOT $ENV{DH_OPTIONS})
 endif()
 
 
-catkin_generate_virtualenv()
+catkin_generate_virtualenv(
+  PYTHON_INTERPRETER python2
+)
 
 # Install files
 install(FILES


### PR DESCRIPTION
this PR is master version of https://github.com/Affonso-Gui/euslime/pull/1 .
in the lastest `catkin_virtualenv`, `python3` is now default interpreter.
so we need to set `PYTHON_INTERPRETER` in `CMakeLists.txt`.